### PR TITLE
Defaults snapshot to initial

### DIFF
--- a/src/main/java/org/gingesnap/cdc/EngineWrapper.java
+++ b/src/main/java/org/gingesnap/cdc/EngineWrapper.java
@@ -72,7 +72,7 @@ public class EngineWrapper {
       props.setProperty("database.user", database.user());
       props.setProperty("database.password", database.password());
       props.setProperty("database.server.name", "gingersnap-eager");
-      props.setProperty("snapshot.mode", "when_needed"); // Behavior when offset not available.
+      props.setProperty("snapshot.mode", "initial"); // Behavior when offset not available.
 
       // Additional configuration
       props.setProperty("tombstones.on.delete", "false"); // Emit single event on delete. Doc says it should be true when using Kafka.

--- a/src/main/java/org/gingesnap/cdc/connector/DatabaseProvider.java
+++ b/src/main/java/org/gingesnap/cdc/connector/DatabaseProvider.java
@@ -52,7 +52,6 @@ public enum DatabaseProvider {
          properties.setProperty("connector.class", SqlServerConnector.class.getCanonicalName());
          properties.setProperty(DATABASE_NAMES.name(), databaseName);
          properties.setProperty("table.include.list", String.format("%s.%s", connector.schema(), connector.table()));
-         properties.setProperty("snapshot.mode", "initial");
          properties.setProperty("database.encrypt", "false");
 
          // SQL Server has a slightly different naming


### PR DESCRIPTION
Only MySQL supports `snapshot.mode` as `when_needed`, so setting the default to `initial`. Meaning that the snapshot is only taken at startup when no offset is found. Fix #19.

[MySQL](https://debezium.io/documentation/reference/2.0/connectors/mysql.html#mysql-property-snapshot-mode)
[Postgres](https://debezium.io/documentation/reference/2.0/connectors/postgresql.html#postgresql-property-snapshot-mode)
[SQL Server](https://debezium.io/documentation/reference/2.0/connectors/sqlserver.html#sqlserver-property-snapshot-mode)